### PR TITLE
GH-2:  Test `s.c.s.bindings.output.contentType`

### DIFF
--- a/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
+++ b/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
@@ -103,8 +103,7 @@ public abstract class FileSourceTests {
 			"trigger.fixedDelay = 100",
 			"trigger.timeUnit = MILLISECONDS",
 			"file.consumer.mode = ref",
-//			"spring.cloud.stream.bindings.output.contentType=text/plain"  GH-2
-	})
+			"spring.cloud.stream.bindings.output.contentType=text/plain" })
 	public static class FilePayloadTests extends FileSourceTests {
 
 		@Test
@@ -112,7 +111,7 @@ public abstract class FileSourceTests {
 			File file = atomicFileCreate("test.txt");
 			Message<?> received = messageCollector.forChannel(source.output()).poll(10, TimeUnit.SECONDS);
 			assertNotNull(received);
-			assertEquals(file, received.getPayload());
+			assertEquals(file.getAbsolutePath(), received.getPayload());
 			file.delete();
 		}
 


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/file#2

Add a `"spring.cloud.stream.bindings.output.contentType=text/plain"` property to the `file.consumer.mode = ref` test-case to be sure that the fix with `MessageConvert`s in the SCSt works well