### PR TITLE
GH-9: Fix compatibility with Spring Cloud 2.0

### DIFF
--- a/spring-cloud-starter-stream-sink-file/README.adoc
+++ b/spring-cloud-starter-stream-sink-file/README.adoc
@@ -25,11 +25,11 @@ N/A (writes to the file system).
 The **$$file$$** $$sink$$ has the following options:
 
 //tag::configuration-properties[]
-$$file.binary$$:: $$A flag to indicate whether content should be written as bytes.$$ *($$Boolean$$, default: `$$false$$`)*
+$$file.binary$$:: $$A flag to indicate whether adding a newline after the write should be suppressed.$$ *($$Boolean$$, default: `$$false$$`)*
 $$file.charset$$:: $$The charset to use when writing text content.$$ *($$String$$, default: `$$UTF-8$$`)*
 $$file.directory$$:: $$The parent directory of the target file.$$ *($$String$$, default: `$$<none>$$`)*
 $$file.directory-expression$$:: $$The expression to evaluate for the parent directory of the target file.$$ *($$Expression$$, default: `$$<none>$$`)*
-$$file.mode$$:: $$The FileExistsMode to use if the target file already exists.$$ *($$FileExistsMode$$, default: `$$<none>$$`, possible values: `APPEND`,`APPEND_NO_FLUSH`,`FAIL`,`IGNORE`,`REPLACE`)*
+$$file.mode$$:: $$The FileExistsMode to use if the target file already exists.$$ *($$FileExistsMode$$, default: `$$<none>$$`, possible values: `APPEND`,`APPEND_NO_FLUSH`,`FAIL`,`IGNORE`,`REPLACE`,`REPLACE_IF_MODIFIED`)*
 $$file.name$$:: $$The name of the target file.$$ *($$String$$, default: `$$file-sink$$`)*
 $$file.name-expression$$:: $$The expression to evaluate for the name of the target file.$$ *($$String$$, default: `$$<none>$$`)*
 $$file.suffix$$:: $$The suffix to append to file name.$$ *($$String$$, default: `$$<empty string>$$`)*

--- a/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,9 @@ public class FileSinkConfiguration {
 
 	@Bean
 	@ServiceActivator(inputChannel = Sink.INPUT)
-	public FileWritingMessageHandler fileWritingMessageHandler(FileNameGenerator fileNameGenerator, FileSinkProperties properties) {
+	public FileWritingMessageHandler fileWritingMessageHandler(FileNameGenerator fileNameGenerator,
+			FileSinkProperties properties) {
+
 		FileWritingMessageHandler handler = (properties.getDirectoryExpression() != null)
 				? new FileWritingMessageHandler(properties.getDirectoryExpression())
 				: new FileWritingMessageHandler(new File(properties.getDirectory()));
@@ -58,4 +60,5 @@ public class FileSinkConfiguration {
 		fileNameGenerator.setExpression(properties.getNameExpression());
 		return fileNameGenerator;
 	}
+
 }

--- a/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkProperties.java
@@ -37,7 +37,7 @@ import org.springframework.validation.annotation.Validated;
 public class FileSinkProperties {
 
 	private static final String DEFAULT_DIR = System.getProperty("java.io.tmpdir") +
-			File.separator + "dataflow" + File.separator + "output";
+			File.separator + "file-sink" + File.separator + "output";
 
 	private static final String DEFAULT_NAME = "file-sink";
 
@@ -160,4 +160,5 @@ public class FileSinkProperties {
 	public boolean isMutuallyExclusiveDirectoryAndDirectoryExpression() {
 		return DEFAULT_DIR.equals(directory) || directoryExpression == null;
 	}
+
 }

--- a/spring-cloud-starter-stream-source-file/README.adoc
+++ b/spring-cloud-starter-stream-source-file/README.adoc
@@ -24,7 +24,7 @@ N/A (Reads from a file system directory).
 ==== Headers:
 
 * `Content-Type: application/octet-stream`
-* `file_orginalFile: <java.io.File>`
+* `file_originalFile: <java.io.File>`
 * `file_name: <file name>`
 
 ==== Payload:
@@ -36,7 +36,7 @@ A `byte[]` filled with the file contents.
 ==== Headers:
 
 * `Content-Type: text/plain`
-* `file_orginalFile: <java.io.File>`
+* `file_originalFile: <java.io.File>`
 * `file_name: <file name>`
 * `correlationId: <UUID>` (same for each line)
 * `sequenceNumber: <n>`

--- a/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,9 @@ import org.springframework.context.annotation.Import;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
 import org.springframework.integration.dsl.IntegrationFlows;
-import org.springframework.integration.dsl.file.FileInboundChannelAdapterSpec;
-import org.springframework.integration.dsl.file.Files;
 import org.springframework.integration.file.FileReadingMessageSource;
+import org.springframework.integration.file.dsl.FileInboundChannelAdapterSpec;
+import org.springframework.integration.file.dsl.Files;
 import org.springframework.util.StringUtils;
 
 /**
@@ -45,8 +45,8 @@ import org.springframework.util.StringUtils;
  */
 @EnableBinding(Source.class)
 @Import(TriggerConfiguration.class)
-@EnableConfigurationProperties({FileSourceProperties.class, FileConsumerProperties.class,
-		TriggerPropertiesMaxMessagesDefaultUnlimited.class})
+@EnableConfigurationProperties({ FileSourceProperties.class, FileConsumerProperties.class,
+		TriggerPropertiesMaxMessagesDefaultUnlimited.class })
 public class FileSourceConfiguration {
 
 	@Autowired
@@ -64,7 +64,8 @@ public class FileSourceConfiguration {
 
 		if (StringUtils.hasText(this.properties.getFilenamePattern())) {
 			messageSourceSpec.patternFilter(this.properties.getFilenamePattern());
-		} else if (this.properties.getFilenameRegex() != null) {
+		}
+		else if (this.properties.getFilenameRegex() != null) {
 			messageSourceSpec.regexFilter(this.properties.getFilenameRegex().pattern());
 		}
 

--- a/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceProperties.java
+++ b/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceProperties.java
@@ -16,12 +16,13 @@
 
 package org.springframework.cloud.stream.app.file.source;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
-
-import javax.validation.constraints.AssertTrue;
 import java.io.File;
 import java.util.regex.Pattern;
+
+import javax.validation.constraints.AssertTrue;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Properties for the file source.
@@ -33,7 +34,7 @@ import java.util.regex.Pattern;
 public class FileSourceProperties {
 
 	private static final String DEFAULT_DIR = System.getProperty("java.io.tmpdir") +
-			File.separator + "dataflow" + File.separator + "input";
+			File.separator + "file-source" + File.separator + "input";
 
 	/**
 	 * The directory to poll for new files.


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/file#9

* Refactor code according the latest dependencies
* Fix typos in the README
* Regenerate READMEs according the latest properties
* Verify the `FileHeaders` come with the output message
* Remove test for the `markersJson = false` - non-relevant any more