### PR TITLE
Leave the contentType header unset in REF mode

### DIFF
--- a/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.app.file.FileConsumerProperties;
+import org.springframework.cloud.stream.app.file.FileReadingMode;
 import org.springframework.cloud.stream.app.file.FileUtils;
 import org.springframework.cloud.stream.app.trigger.TriggerConfiguration;
 import org.springframework.cloud.stream.app.trigger.TriggerPropertiesMaxMessagesDefaultUnlimited;
@@ -73,9 +74,11 @@ public class FileSourceConfiguration {
 
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(messageSourceSpec);
 
-		return FileUtils.enhanceFlowForReadingMode(flowBuilder, this.fileConsumerProperties)
-				.channel(source.output())
-				.get();
+		if (this.fileConsumerProperties.getMode() != FileReadingMode.ref) {
+			flowBuilder = FileUtils.enhanceFlowForReadingMode(flowBuilder, this.fileConsumerProperties);
+		}
+
+		return flowBuilder.channel(source.output()).get();
 	}
 
 }


### PR DESCRIPTION
Resolves #11

  This would allow message consumer to set the desired type using the spring.cloud.stream.bindings.output.contentType property. For example: spring.cloud.stream.bindings.output.contentType=text/plain.